### PR TITLE
Improve session stability on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="description" content="AutoCore AI - Solution SaaS pour automatiser la gestion des rapports d'expertise, factures et communication client pour carrossiers et garages." />
     <title>AutoCore AI | Plateforme de gestion pour carrossiers</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -102,9 +102,11 @@ function App() {
           console.log('[App] Session rafraîchie automatiquement');
           break;
         case 'session_expired':
-          console.log('[App] Session expirée, redirection vers login');
+          console.log('[App] Session expirée');
           toast.error("Votre session a expiré. Veuillez vous reconnecter.");
-          navigate('/login');
+          if (!['/login', '/force-refresh'].includes(location.pathname)) {
+            navigate('/force-refresh');
+          }
           break;
         case 'session_verified':
           console.log('[App] Session vérifiée après retour d\'onglet');
@@ -118,7 +120,7 @@ function App() {
       unsubscribe();
       sessionManager.cleanup();
     };
-  }, [navigate]);
+  }, [navigate, location.pathname]);
 
   // Check session initial
   const memoizedCheckSession = useCallback(() => {

--- a/src/components/invoices/InvoiceEditor.jsx
+++ b/src/components/invoices/InvoiceEditor.jsx
@@ -31,7 +31,7 @@ const invoiceSchema = z.object({
 
 const InvoiceEditor = () => {
   const navigate = useNavigate();
-  const { executeWithValidSession } = useSession();
+  const { executeWithValidSession, refreshSession } = useSession();
   const { invoiceId } = useParams();
 
   // Mode d'utilisation de ce composant
@@ -63,6 +63,11 @@ const InvoiceEditor = () => {
 
   // Provide access to the invoice loader for visibility handler
   const fetchInvoiceDetailsRef = useRef(null);
+
+  // Ensure session is fresh when opening the editor
+  useEffect(() => {
+    refreshSession();
+  }, [refreshSession]);
 
 
   const round = (num) => Math.round(num * 100) / 100;

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -107,6 +107,18 @@ export const AuthProvider = ({ children }) => {
     return () => clearInterval(interval)
   }, [])
 
+  // Sync session across tabs
+  useEffect(() => {
+    const handleStorage = (event) => {
+      if (event.key && event.key.startsWith('sb-') && event.newValue !== event.oldValue) {
+        checkSession()
+      }
+    }
+
+    window.addEventListener('storage', handleStorage)
+    return () => window.removeEventListener('storage', handleStorage)
+  }, [checkSession])
+
   // Set up auth state listener
   useEffect(() => {
     if (!supabase) {

--- a/src/index.css
+++ b/src/index.css
@@ -65,6 +65,8 @@
   body {
     @apply bg-background text-foreground;
     font-family: 'Inter', sans-serif;
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
   }
   
   h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
## Summary
- keep session in sync across browser tabs
- route to a dedicated reconnect page when sessions expire
- refresh session when opening invoice editor
- tweak body styles for smoother mobile interactions
- add mobile web app meta tags

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68623aed5b8c832bacc1948a1f7c975d