### PR TITLE
Fix stripe.js syntax error

### DIFF
--- a/src/lib/stripe.js
+++ b/src/lib/stripe.js
@@ -2,23 +2,7 @@ import { loadStripe } from '@stripe/stripe-js';
 import { createCheckoutSession } from './stripeClient';
 
 let stripePromise;
-export const getStripe = async () => {
-  if (!stripePromise) {
-    try {
-      stripePromise = await loadStripe(
-        import.meta.env.VITE_STRIPE_PUBLISHABLE_KEY
-      );
-    } catch (e) {
-      console.warn('⚠️ Stripe bloqué (Adblock ?)');
-      stripePromise = null;
-    }
-  }
-  return stripePromise;
-};
 
-/**
- * Récupère l’instance Stripe ou la charge si nécessaire
- */
 export const getStripe = async () => {
   if (!stripePromise) {
     try {
@@ -47,5 +31,4 @@ export const redirectToCheckout = async (priceId, mode = 'subscription') => {
     console.error('Erreur redirection checkout :', error);
     throw error;
   }
-}
 };


### PR DESCRIPTION
## Summary
- clean up `src/lib/stripe.js`
- remove duplicate `getStripe` implementation
- fix closing brace in `redirectToCheckout`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68624e6d9b5c832b991ecaccb7cfa8e5